### PR TITLE
Accpeting other public key algorithms in setup_common.sh

### DIFF
--- a/orchestrator/env/setup_common.sh
+++ b/orchestrator/env/setup_common.sh
@@ -21,7 +21,7 @@ then
    fi
 fi
 
-[ -n "$DEFAULT_KEY_LOCATION" ] || DEFAULT_KEY_LOCATION=~/.ssh/id_rsa.pub
+[ -n "$DEFAULT_KEY_LOCATION" ] || DEFAULT_KEY_LOCATION=$(ls ~/.ssh/id_*.pub | head -n1)
 
 [ -e "$DEFAULT_KEY_LOCATION" ] || { echo "Missing public key"; exit -1; }
 


### PR DESCRIPTION
Checking other algorithms when getting DEFAULT_KEY_LOCATION rather than only looking for RSA public key, and taking the first result,